### PR TITLE
Added MIME types and filtering file lists

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ var Resource   = require('deployd/lib/resource'),
     debug      = require('debug')('dpd-fileupload'),
     formidable = require('formidable'),
     fs         = require('fs'),
-    md5        = require('MD5');
+    md5        = require('MD5'),
+    mime       = require('mime');
 
 /**
  * Module setup.
@@ -122,6 +123,10 @@ Fileupload.prototype.handle = function (ctx, next) {
                 }
                 storedObject.filesize = file.size;
                 storedObject.creationDate = new Date().getTime();
+
+                // Store MIME type in object
+                storedObject.mimeType = mime.lookup(file.name);
+
                 self.store.insert(storedObject, function(err, result) {
                     if (err) return processDone(err);
                     debug('stored after event.upload.run %j', err || result || 'none');
@@ -185,15 +190,10 @@ Fileupload.prototype.handle = function (ctx, next) {
 
 Fileupload.prototype.get = function(ctx, next) {
     var self = this,
-        req = ctx.req,
-        reqParam = {};
-
-    if (ctx.query.subdir) {
-        reqParam.subdir = ctx.query.subdir;
-    }
+        req = ctx.req;
 
     if (!ctx.query.id) {
-        self.store.find(reqParam, function(err, result) {
+        self.store.find(ctx.query, function(err, result) {
             ctx.done(err, result);
         });
     }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "formidable": "~1.0.14",
     "debug": "~0.7.4",
-    "MD5": "~1.2.0"
+    "MD5": "~1.2.0",
+    "mime": "~1.2.11"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Thanks for the great project, it's exactly what we needed.

I added two small features: 
- The MIME type of files are automatically detected and stored along with the other meta data under the "mimeType" attribute.
- Before you could only filter the list of files (via GET requests) with the uploadDir. I removed the restriction so that you can filter via tags or other things.
