### PR TITLE
Fixed bug for deleting without a subdirectory

### DIFF
--- a/index.js
+++ b/index.js
@@ -225,10 +225,18 @@ Fileupload.prototype.del = function(ctx, next) {
             }
             self.store.remove({id: fileId}, function(err) {
                 if (err) return ctx.done(err);
-                fs.unlink(uploadDir + subdir + "/" + result.filename, function(err) {
-                    if (err) return ctx.done(err);
-                    ctx.done(null, {statusCode: 200, message: "File " + result.filename + " successfuly deleted"});
-                });
+                //Fixed in case you don't upload to a subdir
+                if(subdir){
+                    fs.unlink(uploadDir + subdir + "/" + result.filename, function(err) {
+                        if (err) return ctx.done(err);
+                        ctx.done(null, {statusCode: 200, message: "File " + result.filename + " successfuly deleted"});
+                    });
+                } else {
+                    fs.unlink(uploadDir + "/" + result.filename, function(err) {
+                        if (err) return ctx.done(err);
+                        ctx.done(null, {statusCode: 200, message: "File " + result.filename + " successfuly deleted"});
+                    });
+                }
             });
         }
     });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dpd-fileupload",
   "description": "File uploader for Deployd",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "author": "Nicolas Ritouet <nicolas@ritouet.com>",
   "dependencies": {
     "formidable": "~1.0.17",


### PR DESCRIPTION
Stumbled across some deleting error when you don't use a subdirectory. Couldn't unlink the file because the `subdir` variable swiched to `undefined`. Hope you like it.