### PR TITLE
Fixed ENAME too long error

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,6 @@ function Fileupload(options) {
             publicDir = dirToCheck;
         }
     }
-    publicDir = publicDir + "/";
 
     this.config = {
         directory: this.config.directory || 'upload',


### PR DESCRIPTION
It was going into a loop because of that line. If you had something else in mind with that line, change that and feel free to cancel this PR.