### PR TITLE
[fix] ENAME too long

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,6 @@ function Fileupload(options) {
             publicDir = dirToCheck;
         }
     }
-    publicDir = publicDir + "/";
 
     this.config = {
         directory: this.config.directory || 'upload',

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function Fileupload(options) {
 
     this.config = {
         directory: this.config.directory || 'upload',
-        fullDirectory: __dirname + publicDir + (this.config.directory || 'upload') + "/"
+        fullDirectory: __dirname + publicDir + "/" + (this.config.directory || 'upload') + "/"
     };
 
     if (this.name === this.config.directory) {


### PR DESCRIPTION
I have done the new fix about `dpd-fileupload`. It was getting inside a loop. Now it works perfectly. You should still add a verification there. See the comment

```
this.config = {
        directory: this.config.directory || 'upload',
        //Should do a verification for this.config.directory so it can accept both 'upload' or '/upload'
        fullDirectory: __dirname + publicDir + "/" + (this.config.directory || 'upload') + "/"
 };
```